### PR TITLE
ストックしている軌跡の投球をスローで再生できるようにした

### DIFF
--- a/Scenes/AccelerationMotion.unity
+++ b/Scenes/AccelerationMotion.unity
@@ -411,6 +411,112 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c4ea8d4c5616c234f816f577b6f4d4da, type: 3}
+--- !u!1 &1472555277
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1472555282}
+  - component: {fileID: 1472555281}
+  - component: {fileID: 1472555280}
+  - component: {fileID: 1472555279}
+  - component: {fileID: 1472555278}
+  m_Layer: 5
+  m_Name: Quad (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1472555278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472555277}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15d22d4a7199cee4ba638c8fdbb0b655, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  selectMode: {fileID: 0}
+--- !u!64 &1472555279
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472555277}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1472555280
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472555277}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1472555281
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472555277}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1472555282
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472555277}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1600895062}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1600895057
 GameObject:
   m_ObjectHideFlags: 0
@@ -513,9 +619,10 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1600895057}
   m_LocalRotation: {x: -0, y: 0.54772, z: -0, w: 0.83666164}
-  m_LocalPosition: {x: 0.777, y: 2, z: 0}
+  m_LocalPosition: {x: 0.786, y: 1.184, z: -0.021}
   m_LocalScale: {x: 0.2, y: 0.2, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1472555282}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 66.421005, z: 0}
@@ -532,6 +639,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trajectoryColor: {fileID: 1600895064}
+  playSlowMotionUI: {fileID: 1472555278}
 --- !u!114 &1600895064
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Scenes/AccelerationMotion.unity
+++ b/Scenes/AccelerationMotion.unity
@@ -443,7 +443,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15d22d4a7199cee4ba638c8fdbb0b655, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectMode: {fileID: 0}
+  selectMode: {fileID: 1600895063}
 --- !u!64 &1472555279
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -640,6 +640,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   trajectoryColor: {fileID: 1600895064}
   playSlowMotionUI: {fileID: 1472555278}
+  replayBall: {fileID: 1467655939423550467, guid: 91c07f3749500ce4fb7fdc4bce787ebb,
+    type: 3}
 --- !u!114 &1600895064
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Scripts/System/SelectMode.cs
+++ b/Scripts/System/SelectMode.cs
@@ -49,6 +49,7 @@ public class SelectMode : MonoBehaviour
         {
             trajectoryColor.ChangeAlpha(FADE_VALUE);
             trajectoryColor.ChangeAlpha(OPAQUE_VALUE, 0);
+            curretTrajectoryID = 0;
             playSlowMotionUI.gameObject.SetActive(true);
         }
 

--- a/Scripts/System/SelectMode.cs
+++ b/Scripts/System/SelectMode.cs
@@ -10,6 +10,7 @@ public class SelectMode : MonoBehaviour
     float OPAQUE_VALUE = 1.0f;
     public bool IsSelectMode { get; private set; }
     [SerializeField] TrajectoryColor trajectoryColor;
+    [SerializeField] PlaySlowMotionUI playSlowMotionUI;
 
     // Start is called before the first frame update
     void Start()
@@ -38,11 +39,13 @@ public class SelectMode : MonoBehaviour
         if (IsSelectMode)
         {
             trajectoryColor.ChangeAlpha(OPAQUE_VALUE);
+            playSlowMotionUI.gameObject.SetActive(false);
         }
         else
         {
             trajectoryColor.ChangeAlpha(FADE_VALUE);
             trajectoryColor.ChangeAlpha(OPAQUE_VALUE, 0);
+            playSlowMotionUI.gameObject.SetActive(true);
         }
 
         IsSelectMode = !IsSelectMode;

--- a/Scripts/System/TrajectoryControl.cs
+++ b/Scripts/System/TrajectoryControl.cs
@@ -5,12 +5,13 @@ using UnityEngine;
 public class TrajectoryControl : MonoBehaviour
 {
     public Vector3 ThrowVelocity { private get; set; }
+    Vector3 throwPosition = new Vector3(-2.0f, 2.0f, 0.0f);
     public static List<GameObject> TrajectoryParents = new List<GameObject>();
 
     public void StockTrajectory()
     {
         alineTrajectory();
-        transform.position = new Vector3(-2.0f, 2.0f, 0.0f);
+        transform.position = throwPosition;
         TrajectoryParents.Add(gameObject);
     }
 
@@ -21,5 +22,11 @@ public class TrajectoryControl : MonoBehaviour
         var degree = radian * 180.0f / Mathf.PI;
 
         transform.rotation = Quaternion.Euler(0.0f, -1 * degree, 0.0f);
+    }
+
+    public Vector3[] GetReplayData()
+    {
+        var replayVelocity = new Vector3(0, ThrowVelocity.y, Mathf.Sqrt(Mathf.Pow(ThrowVelocity.x, 2) + Mathf.Pow(ThrowVelocity.z, 2)));
+        return new Vector3[] { replayVelocity, throwPosition };
     }
 }

--- a/Scripts/UI/PlaySlowMotionUI.cs
+++ b/Scripts/UI/PlaySlowMotionUI.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+public class PlaySlowMotionUI : MonoBehaviour
+{
+    [SerializeField] SelectMode selectMode;
+
+    public void LaserSelectReceiver()
+    {
+        
+    }
+}

--- a/Scripts/UI/PlaySlowMotionUI.cs
+++ b/Scripts/UI/PlaySlowMotionUI.cs
@@ -1,11 +1,11 @@
 ﻿using UnityEngine;
 
-public class PlaySlowMotionUI : MonoBehaviour
+public class PlaySlowMotionUI : MonoBehaviour, ILaserSelectReceiver
 {
     [SerializeField] SelectMode selectMode;
 
     public void LaserSelectReceiver()
     {
-        
+        selectMode.PlaySlowMotion();
     }
 }

--- a/Scripts/UI/PlaySlowMotionUI.cs.meta
+++ b/Scripts/UI/PlaySlowMotionUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15d22d4a7199cee4ba638c8fdbb0b655
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
選択モード時に表示されるボタンUIを押すと選択している軌跡の投球をスロー（1/3倍速）で再生する機能を追加