### PR TITLE
ストックした軌跡を回転させる機能の実装

### DIFF
--- a/Resources/TrajectoryParent/Prefabs/TrajectoryParent.prefab
+++ b/Resources/TrajectoryParent/Prefabs/TrajectoryParent.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6137461621656638346}
+  - component: {fileID: 5983034577201900470}
   m_Layer: 0
   m_Name: TrajectoryParent
   m_TagString: Untagged
@@ -30,3 +31,16 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5983034577201900470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6382629404737509556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17c0752a4795af343a59b0ea4d812b3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  turnAxis: {fileID: 0}

--- a/Scripts/System/SelectMode.cs
+++ b/Scripts/System/SelectMode.cs
@@ -74,19 +74,20 @@ public class SelectMode : MonoBehaviour
         var gravity = 9.81f;
         var elapsedTime = 0.0f;
         trajectoryColor.ChangeAlpha(FADE_VALUE, curretTrajectoryID);
-        var replayData = TrajectoryControl.TrajectoryParents[curretTrajectoryID].GetComponent<TrajectoryControl>().GetReplayData();
+        var replayVelocity = TrajectoryControl.TrajectoryParents[curretTrajectoryID].GetComponent<TrajectoryControl>().ThrowVelocity;
 
-        var instantReplayBall = Instantiate(replayBall, replayData[1], Quaternion.identity);
+        var instantReplayBall = Instantiate(replayBall, TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform.position, TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform.rotation);
+        instantReplayBall.transform.parent = TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform;
 
-        this.UpdateAsObservable()
+        instantReplayBall.UpdateAsObservable()
             .Subscribe(_ =>
             {
-                var coordinateX = replayData[1].x + replayData[0].x * elapsedTime;
-                var coordinateY = replayData[1].y + replayData[0].y * elapsedTime - gravity * Mathf.Pow(elapsedTime, 2) / 2;
-                var coordinateZ = replayData[1].z + replayData[0].z * elapsedTime;
+                var coordinateX = replayVelocity.x * elapsedTime;
+                var coordinateY = replayVelocity.y * elapsedTime - gravity * Mathf.Pow(elapsedTime, 2) / 2;
+                var coordinateZ = replayVelocity.z * elapsedTime;
 
                 var position = new Vector3(coordinateX, coordinateY, coordinateZ);
-                instantReplayBall.transform.position = position;
+                instantReplayBall.transform.localPosition = position;
 
                 elapsedTime += Time.deltaTime / replaySpeed;
 
@@ -95,7 +96,6 @@ public class SelectMode : MonoBehaviour
                     trajectoryColor.ChangeAlpha(OPAQUE_VALUE, curretTrajectoryID);
                     Destroy(instantReplayBall);
                 }
-            })
-            .AddTo(instantReplayBall);
+            });
     }
 }

--- a/Scripts/System/Trajectory.cs
+++ b/Scripts/System/Trajectory.cs
@@ -20,7 +20,6 @@ public class Trajectory : MonoBehaviour
     public GameObject CreateParent(Vector3 throwPosition)
     {
         instantTrajectoryParent = Instantiate(trajectoryParent, throwPosition, Quaternion.identity);
-        instantTrajectoryParent.AddComponent(typeof(TrajectoryControl));
         return instantTrajectoryParent;
     }
 

--- a/Scripts/System/TrajectoryControl.cs
+++ b/Scripts/System/TrajectoryControl.cs
@@ -1,17 +1,49 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
+using UniRx.Triggers;
+using UniRx;
 
 public class TrajectoryControl : MonoBehaviour
 {
     public Vector3 ThrowVelocity { private get; set; }
     Vector3 throwPosition = new Vector3(-2.0f, 2.0f, 0.0f);
     public static List<GameObject> TrajectoryParents = new List<GameObject>();
+    static GameObject turnAxis;
+    float turnSpeed = 5;
+
+    void Start()
+    {
+        Initialize();
+    }
+
+    public void Initialize()
+    {
+        if (turnAxis != null)
+        {
+            return;
+        }
+
+        turnAxis = GameObject.Find("TurnAxis");
+        turnAxis.UpdateAsObservable()
+            .Subscribe(_ =>
+            {
+                var stickAxis = OVRInput.Get(OVRInput.RawAxis2D.LThumbstick);
+                turnAxis.transform.Rotate(0, stickAxis.x * turnSpeed, 0);
+            });
+
+        turnAxis.UpdateAsObservable()
+            .Subscribe(_ =>
+            {
+                var stickAxis = OVRInput.Get(OVRInput.RawAxis2D.RThumbstick);
+                turnAxis.transform.Rotate(0, stickAxis.x * turnSpeed, 0);
+            });
+    }
 
     public void StockTrajectory()
     {
         alineTrajectory();
         transform.position = throwPosition;
+        transform.parent = turnAxis.transform;
         TrajectoryParents.Add(gameObject);
     }
 

--- a/Scripts/System/TrajectoryControl.cs
+++ b/Scripts/System/TrajectoryControl.cs
@@ -9,7 +9,6 @@ public class TrajectoryControl : MonoBehaviour
     Vector3 throwPosition = new Vector3(-2.0f, 2.0f, 0.0f);
     public static List<GameObject> TrajectoryParents = new List<GameObject>();
     static GameObject turnAxis;
-    float turnSpeed = 5;
 
     void Start()
     {
@@ -28,14 +27,14 @@ public class TrajectoryControl : MonoBehaviour
             .Subscribe(_ =>
             {
                 var stickAxis = OVRInput.Get(OVRInput.RawAxis2D.LThumbstick);
-                turnAxis.transform.Rotate(0, stickAxis.x * turnSpeed, 0);
+                turnAxis.transform.Rotate(0, Mathf.Round(stickAxis.x), 0);
             });
 
         turnAxis.UpdateAsObservable()
             .Subscribe(_ =>
             {
                 var stickAxis = OVRInput.Get(OVRInput.RawAxis2D.RThumbstick);
-                turnAxis.transform.Rotate(0, stickAxis.x * turnSpeed, 0);
+                turnAxis.transform.Rotate(0, Mathf.Round(stickAxis.x), 0);
             });
     }
 

--- a/Scripts/System/TrajectoryControl.cs
+++ b/Scripts/System/TrajectoryControl.cs
@@ -5,7 +5,7 @@ using UniRx;
 
 public class TrajectoryControl : MonoBehaviour
 {
-    public Vector3 ThrowVelocity { private get; set; }
+    public Vector3 ThrowVelocity { get; set; }
     Vector3 throwPosition = new Vector3(-2.0f, 2.0f, 0.0f);
     public static List<GameObject> TrajectoryParents = new List<GameObject>();
     static GameObject turnAxis;
@@ -53,11 +53,5 @@ public class TrajectoryControl : MonoBehaviour
         var degree = radian * 180.0f / Mathf.PI;
 
         transform.rotation = Quaternion.Euler(0.0f, -1 * degree, 0.0f);
-    }
-
-    public Vector3[] GetReplayData()
-    {
-        var replayVelocity = new Vector3(0, ThrowVelocity.y, Mathf.Sqrt(Mathf.Pow(ThrowVelocity.x, 2) + Mathf.Pow(ThrowVelocity.z, 2)));
-        return new Vector3[] { replayVelocity, throwPosition };
     }
 }


### PR DESCRIPTION
スティックのｘ軸入力で軌跡群を回転させる。その場合にスロー再生も回転に合わせられるようにした。ただし、現PRの時点では回転をリセットできず新しい軌跡をストックすると既存の軌跡の回転とずれが生じてしまう。