### PR TITLE
投球リプレイ機能のスピードを任意に変更できる機能の追加

### DIFF
--- a/Scenes/AccelerationMotion.unity
+++ b/Scenes/AccelerationMotion.unity
@@ -234,6 +234,113 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &389514597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 389514598}
+  - component: {fileID: 389514602}
+  - component: {fileID: 389514601}
+  - component: {fileID: 389514600}
+  - component: {fileID: 389514599}
+  m_Layer: 5
+  m_Name: Quad (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &389514598
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389514597}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.1, y: -0.2999997, z: 0}
+  m_LocalScale: {x: 1, y: 0.40000004, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1472555282}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &389514599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389514597}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c83c0a86f739224486ce5e7cdcca1dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  adjustDirection: 1
+  selectMode: {fileID: 1600895063}
+--- !u!64 &389514600
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389514597}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &389514601
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389514597}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &389514602
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 389514597}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &452603578
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -565,7 +672,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1472555278
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -648,10 +755,119 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.1, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1531358002}
+  - {fileID: 389514598}
   m_Father: {fileID: 1600895062}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1531358001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1531358002}
+  - component: {fileID: 1531358006}
+  - component: {fileID: 1531358005}
+  - component: {fileID: 1531358004}
+  - component: {fileID: 1531358003}
+  m_Layer: 5
+  m_Name: Quad (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1531358002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531358001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.1, y: 0.2999997, z: 0}
+  m_LocalScale: {x: 1, y: 0.40000004, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1472555282}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1531358003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531358001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c83c0a86f739224486ce5e7cdcca1dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  adjustDirection: 0
+  selectMode: {fileID: 1600895063}
+--- !u!64 &1531358004
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531358001}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1531358005
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531358001}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1531358006
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531358001}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1600895057
 GameObject:
   m_ObjectHideFlags: 0

--- a/Scripts/System/SelectMode.cs
+++ b/Scripts/System/SelectMode.cs
@@ -9,7 +9,9 @@ public class SelectMode : MonoBehaviour
     float FADE_VALUE = 0.3f;
     float OPAQUE_VALUE = 1.0f;
     public bool IsSelectMode { get; private set; }
-    float replaySpeed = 3;
+    int replaySpeed;
+    int ADJUST_VALUE_MAX = 5;
+    int ADJUST_VALUE_MIN = 1;
     [SerializeField] TrajectoryColor trajectoryColor;
     [SerializeField] PlaySlowMotionUI playSlowMotionUI;
     [SerializeField] GameObject replayBall;
@@ -31,6 +33,9 @@ public class SelectMode : MonoBehaviour
             .Where(_ => IsSelectMode)
             .Where(_ => OVRInput.GetDown(OVRInput.RawButton.RThumbstickDown) || OVRInput.GetDown(OVRInput.RawButton.LThumbstickDown))
             .Subscribe(_ => selectTrajectory(1));
+
+        playSlowMotionUI.gameObject.SetActive(false);
+        replaySpeed = 3;
     }
 
     public void ChangeSelectMode()
@@ -97,5 +102,20 @@ public class SelectMode : MonoBehaviour
                     Destroy(instantReplayBall);
                 }
             });
+    }
+
+    public void AdjustReplaySpeed(int adjustValue)
+    {
+        replaySpeed += adjustValue;
+
+        if (replaySpeed < ADJUST_VALUE_MIN)
+        {
+            replaySpeed = ADJUST_VALUE_MIN;
+        }
+
+        if (replaySpeed > ADJUST_VALUE_MAX)
+        {
+            replaySpeed = ADJUST_VALUE_MAX;
+        }
     }
 }

--- a/Scripts/UI/AdjustReplaySpeedUI.cs
+++ b/Scripts/UI/AdjustReplaySpeedUI.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+
+public class AdjustReplaySpeedUI : MonoBehaviour, ILaserSelectReceiver
+{
+    enum AdjustDirection
+    {
+        Up, Down
+    }
+
+    [SerializeField] AdjustDirection adjustDirection;
+    [SerializeField] SelectMode selectMode;
+
+    public void LaserSelectReceiver()
+    {
+        switch (adjustDirection)
+        {
+            case AdjustDirection.Up:
+                selectMode.AdjustReplaySpeed(1);
+                break;
+            case AdjustDirection.Down:
+                selectMode.AdjustReplaySpeed(-1);
+                break;
+        }
+    }
+}

--- a/Scripts/UI/AdjustReplaySpeedUI.cs
+++ b/Scripts/UI/AdjustReplaySpeedUI.cs
@@ -15,10 +15,10 @@ public class AdjustReplaySpeedUI : MonoBehaviour, ILaserSelectReceiver
         switch (adjustDirection)
         {
             case AdjustDirection.Up:
-                selectMode.AdjustReplaySpeed(1);
+                selectMode.AdjustReplaySpeed(-1);
                 break;
             case AdjustDirection.Down:
-                selectMode.AdjustReplaySpeed(-1);
+                selectMode.AdjustReplaySpeed(1);
                 break;
         }
     }

--- a/Scripts/UI/AdjustReplaySpeedUI.cs.meta
+++ b/Scripts/UI/AdjustReplaySpeedUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c83c0a86f739224486ce5e7cdcca1dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
選択モード移行と同時に出現するUIを操作することによってリプレイの再生速度を変更できる。
現時点で速度の幅は1倍速～1/5倍速まで