### PR TITLE
スロー再生時のボールを連続で投球する

### DIFF
--- a/Resources/Ball/Prefabs/TrajectoryBall.prefab
+++ b/Resources/Ball/Prefabs/TrajectoryBall.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6067557008312481937}
   m_Layer: 0
   m_Name: TrajectoryBall
-  m_TagString: Untagged
+  m_TagString: Trajectory
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Scripts/System/SelectMode.cs
+++ b/Scripts/System/SelectMode.cs
@@ -83,6 +83,7 @@ public class SelectMode : MonoBehaviour
 
         var instantReplayBall = Instantiate(replayBall, TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform.position, TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform.rotation);
         instantReplayBall.transform.parent = TrajectoryControl.TrajectoryParents[curretTrajectoryID].transform;
+        instantReplayBall.tag = "Untagged";
 
         instantReplayBall.UpdateAsObservable()
             .Subscribe(_ =>

--- a/Scripts/System/TrajectoryColor.cs
+++ b/Scripts/System/TrajectoryColor.cs
@@ -6,8 +6,9 @@ public class TrajectoryColor : MonoBehaviour
     public void ChangeAlpha(float alphaValue,int index)
     {
         TrajectoryControl.TrajectoryParents[index].GetComponentsInChildren<MeshRenderer>()
-                .Select(renderer => renderer.material.color = new Color(renderer.material.color.r, renderer.material.color.g, renderer.material.color.b, alphaValue))
-                .ToArray();
+            .Where(renderer => renderer.gameObject.tag == "Trajectory")
+            .Select(renderer => renderer.material.color = new Color(renderer.material.color.r, renderer.material.color.g, renderer.material.color.b, alphaValue))
+            .ToArray();
     }
 
     public void ChangeAlpha(float alphaValue)

--- a/Scripts/UI/PlaySlowMotionUI.cs
+++ b/Scripts/UI/PlaySlowMotionUI.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Threading.Tasks;
 
 public class PlaySlowMotionUI : MonoBehaviour, VRUI
 {
@@ -6,6 +7,15 @@ public class PlaySlowMotionUI : MonoBehaviour, VRUI
 
     public void Receiver()
     {
-        selectMode.PlaySlowMotion();
+        blazeThrow();
+    }
+
+    async void blazeThrow()
+    {
+        for(int count = 0; count < 3; count++)
+        {
+            selectMode.PlaySlowMotion();
+            await Task.Delay(250);
+        }
     }
 }

--- a/Scripts/UI/PlaySlowMotionUI.cs
+++ b/Scripts/UI/PlaySlowMotionUI.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 public class PlaySlowMotionUI : MonoBehaviour, VRUI
 {
     [SerializeField] SelectMode selectMode;
+    int delayTime = 250;
 
     public void Receiver()
     {
@@ -15,7 +16,7 @@ public class PlaySlowMotionUI : MonoBehaviour, VRUI
         for(int count = 0; count < 3; count++)
         {
             selectMode.PlaySlowMotion();
-            await Task.Delay(250);
+            await Task.Delay(delayTime);
         }
     }
 }


### PR DESCRIPTION
スロー再生時のボール投球を自動で連続発射に変更した。現時点では3連発射に設定している。
ついでにスロー再生時の軌跡の透明化に動くボールは影響しないように修正を行った。

関連PR
https://github.com/Inspiron5680/VRPhysics/pull/1