### PR TITLE
ストックとリプレイ処理でのバグ修正

### DIFF
--- a/Scripts/System/Pitching.cs
+++ b/Scripts/System/Pitching.cs
@@ -41,6 +41,7 @@ public class Pitching : MonoBehaviour
                     switchPlayerMode.ChangePlayerMode();
                 }
 
+                TrajectoryControl.ResetTurnAxis();
                 gameObject.transform.parent = null;
                 trajectory.Retry();
             });

--- a/Scripts/System/Pitching.cs
+++ b/Scripts/System/Pitching.cs
@@ -41,7 +41,6 @@ public class Pitching : MonoBehaviour
                     switchPlayerMode.ChangePlayerMode();
                 }
 
-                TrajectoryControl.ResetTurnAxis();
                 gameObject.transform.parent = null;
                 trajectory.Retry();
             });

--- a/Scripts/System/TrajectoryControl.cs
+++ b/Scripts/System/TrajectoryControl.cs
@@ -49,6 +49,7 @@ public class TrajectoryControl : MonoBehaviour
 
     public void StockTrajectory()
     {
+        ResetTurnAxis();
         alineTrajectory();
         transform.position = throwPosition;
         transform.parent = turnAxis.transform;

--- a/Scripts/UI/PlaySlowMotionUI.cs
+++ b/Scripts/UI/PlaySlowMotionUI.cs
@@ -8,6 +8,11 @@ public class PlaySlowMotionUI : MonoBehaviour, VRUI
 
     public void Receiver()
     {
+        if (TrajectoryControl.TrajectoryParents.Count == 0)
+        {
+            return;
+        }
+
         blazeThrow();
     }
 


### PR DESCRIPTION
・ストックをする際にもともとストックしてあった軌跡を回転させていると回転がリセットされずにストック処理を行って軌跡がずれた状態になっていたの
・ストックを行っていない状態でリプレイを行うとフリーズする

以上のバグを修正